### PR TITLE
[FEAT] 카테고리 별 매장 조회 기능 구현

### DIFF
--- a/spring/src/main/java/com/goruna/spring/book/entity/Book.java
+++ b/spring/src/main/java/com/goruna/spring/book/entity/Book.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "shop")
+@Table(name = "book")
 @NoArgsConstructor
 @Getter
 public class Book extends BaseTimeEntity {

--- a/spring/src/main/java/com/goruna/spring/common/exception/ErrorCodeType.java
+++ b/spring/src/main/java/com/goruna/spring/common/exception/ErrorCodeType.java
@@ -21,6 +21,7 @@ public enum ErrorCodeType {
     // 공통 오류
     COMMON_ERROR(HttpStatus.BAD_REQUEST, "COMMON_ERROR", "오류가 발생하였습니다. 관리자에게 문의 바랍니다."),
     DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_ERROR_002", "데이터가 존재하지 않습니다."),
+    INVALID_VALUE(HttpStatus.BAD_REQUEST, "COMMON_ERROR_003", "유효하지 않은 값입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/spring/src/main/java/com/goruna/spring/shop/controller/ShopCategoryController.java
+++ b/spring/src/main/java/com/goruna/spring/shop/controller/ShopCategoryController.java
@@ -21,7 +21,7 @@ public class ShopCategoryController {
 
     @GetMapping
     @Operation(summary = "매장 카테고리 데이터 전체 조회", description = "매장 카테고리 데이터 전체를 조회합니다.")
-    public ApiResponse<List<ShopCategoryReadResDTO>> readAllCategories() {
+    public ApiResponse<?> readAllCategories() {
         List<ShopCategoryReadResDTO> shopCategoryReadResDTO = shopCategoryService.readAllCategories();
         return ResponseUtil.successResponse("매장 카테고리 전체 데이터가 성공적으로 조회되었습니다", shopCategoryReadResDTO).getBody();
     }

--- a/spring/src/main/java/com/goruna/spring/shop/controller/ShopController.java
+++ b/spring/src/main/java/com/goruna/spring/shop/controller/ShopController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -23,8 +24,11 @@ public class ShopController {
             summary = "카테고리 별 매장 목록 데이터 조회",
             description = "카테고리 별 매장 목록 데이터를 조회합니다."
     )
-    public ApiResponse<?> readShopsByCategory(@PathVariable(value = "categorySeq") Long categorySeq) {
-        List<ShopListReadResDTO> shopListReadResDTOS = shopService.readShopsByCategory(categorySeq);
+    public ApiResponse<?> readShopsByCategory(
+            @PathVariable(value = "categorySeq") Long categorySeq,
+            @RequestParam(defaultValue = "1") Integer page
+    ) {
+        List<ShopListReadResDTO> shopListReadResDTOS = shopService.readShopsByCategory(categorySeq, page);
         return ResponseUtil.successResponse("카테고리 별 매장 목록 데이터가 성공적으로 조회되었습니다.", shopListReadResDTOS).getBody();
     }
 }

--- a/spring/src/main/java/com/goruna/spring/shop/controller/ShopController.java
+++ b/spring/src/main/java/com/goruna/spring/shop/controller/ShopController.java
@@ -23,7 +23,7 @@ public class ShopController {
             summary = "카테고리 별 매장 목록 데이터 조회",
             description = "카테고리 별 매장 목록 데이터를 조회합니다."
     )
-    public ApiResponse<List<ShopListReadResDTO>> readShopsByCategory(@PathVariable(value = "categorySeq") Long categorySeq) {
+    public ApiResponse<?> readShopsByCategory(@PathVariable(value = "categorySeq") Long categorySeq) {
         List<ShopListReadResDTO> shopListReadResDTOS = shopService.readShopsByCategory(categorySeq);
         return ResponseUtil.successResponse("카테고리 별 매장 목록 데이터가 성공적으로 조회되었습니다.", shopListReadResDTOS).getBody();
     }

--- a/spring/src/main/java/com/goruna/spring/shop/controller/ShopController.java
+++ b/spring/src/main/java/com/goruna/spring/shop/controller/ShopController.java
@@ -1,0 +1,30 @@
+package com.goruna.spring.shop.controller;
+
+import com.goruna.spring.common.response.ApiResponse;
+import com.goruna.spring.common.response.ResponseUtil;
+import com.goruna.spring.shop.dto.ShopListReadResDTO;
+import com.goruna.spring.shop.service.ShopService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ShopController {
+
+    private final ShopService shopService;
+
+    @GetMapping("/{categorySeq}/shop")
+    @Operation(
+            summary = "카테고리 별 매장 목록 데이터 조회",
+            description = "카테고리 별 매장 목록 데이터를 조회합니다."
+    )
+    public ApiResponse<List<ShopListReadResDTO>> readShopsByCategory(@PathVariable(value = "categorySeq") Long categorySeq) {
+        List<ShopListReadResDTO> shopListReadResDTOS = shopService.readShopsByCategory(categorySeq);
+        return ResponseUtil.successResponse("카테고리 별 매장 목록 데이터가 성공적으로 조회되었습니다.", shopListReadResDTOS).getBody();
+    }
+}

--- a/spring/src/main/java/com/goruna/spring/shop/dto/ShopListReadResDTO.java
+++ b/spring/src/main/java/com/goruna/spring/shop/dto/ShopListReadResDTO.java
@@ -1,0 +1,23 @@
+package com.goruna.spring.shop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class ShopListReadResDTO {
+
+    private Long shopSeq;
+
+    private String shopName;
+
+    private String shopImgUrl;
+
+    private String categoryName;
+
+    private int shopProductOriginalPrice;
+
+    private int shopProductSalePrice;
+}

--- a/spring/src/main/java/com/goruna/spring/shop/entity/Shop.java
+++ b/spring/src/main/java/com/goruna/spring/shop/entity/Shop.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
 @Table(name = "shop")
@@ -67,8 +68,8 @@ public class Shop extends BaseTimeEntity {
     @Column(name = "shop_img_url", nullable = true)
     private String shopImgUrl;
 
-    @Column(name = "shop_deadline", nullable = true)
-    private LocalDateTime shopDeadline;
+    @Column(name = "shop_closed_at", nullable = true)
+    private LocalTime shopClosedAt;
 
     @Column(name = "shop_product_img_url", nullable = true)
     private String shopProductImgUrl;

--- a/spring/src/main/java/com/goruna/spring/shop/repository/ShopRepository.java
+++ b/spring/src/main/java/com/goruna/spring/shop/repository/ShopRepository.java
@@ -1,0 +1,14 @@
+package com.goruna.spring.shop.repository;
+
+import com.goruna.spring.shop.entity.Shop;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ShopRepository extends JpaRepository<Shop, Long> {
+
+    @Query("SELECT s FROM Shop s WHERE s.shopCategory.categorySeq = :categorySeq AND s.shopApprStatus = true AND s.shopDelStatus = false")
+    List<Shop> readShopsByCategory(@Param("categorySeq") Long categorySeq);
+}

--- a/spring/src/main/java/com/goruna/spring/shop/repository/ShopRepository.java
+++ b/spring/src/main/java/com/goruna/spring/shop/repository/ShopRepository.java
@@ -1,6 +1,7 @@
 package com.goruna.spring.shop.repository;
 
 import com.goruna.spring.shop.entity.Shop;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,5 +11,5 @@ import java.util.List;
 public interface ShopRepository extends JpaRepository<Shop, Long> {
 
     @Query("SELECT s FROM Shop s WHERE s.shopCategory.categorySeq = :categorySeq AND s.shopApprStatus = true AND s.shopDelStatus = false")
-    List<Shop> readShopsByCategory(@Param("categorySeq") Long categorySeq);
+    List<Shop> readShopsByCategory(@Param("categorySeq") Long categorySeq, Pageable pageable);
 }

--- a/spring/src/main/java/com/goruna/spring/shop/service/ShopService.java
+++ b/spring/src/main/java/com/goruna/spring/shop/service/ShopService.java
@@ -1,0 +1,32 @@
+package com.goruna.spring.shop.service;
+
+import com.goruna.spring.shop.dto.ShopListReadResDTO;
+import com.goruna.spring.shop.entity.Shop;
+import com.goruna.spring.shop.repository.ShopRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequestMapping("/api/v1/category")
+@RequiredArgsConstructor
+public class ShopService {
+
+    private final ShopRepository shopRepository;
+    private final ModelMapper modelMapper;
+
+    public List<ShopListReadResDTO> readShopsByCategory(Long categorySeq) {
+        List<Shop> shops = shopRepository.readShopsByCategory(categorySeq);
+        return shops.stream()
+                .map(shop -> {
+                    ShopListReadResDTO shopListReadResDTO = modelMapper.map(shop, ShopListReadResDTO.class);
+                    shopListReadResDTO.setCategoryName(shop.getShopCategory().getCategoryName()); // 카테고리 이름 추가
+                    return shopListReadResDTO;
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/spring/src/main/java/com/goruna/spring/shop/service/ShopService.java
+++ b/spring/src/main/java/com/goruna/spring/shop/service/ShopService.java
@@ -1,10 +1,14 @@
 package com.goruna.spring.shop.service;
 
+import com.goruna.spring.common.exception.CustomException;
+import com.goruna.spring.common.exception.ErrorCodeType;
 import com.goruna.spring.shop.dto.ShopListReadResDTO;
 import com.goruna.spring.shop.entity.Shop;
 import com.goruna.spring.shop.repository.ShopRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -19,8 +23,15 @@ public class ShopService {
     private final ShopRepository shopRepository;
     private final ModelMapper modelMapper;
 
-    public List<ShopListReadResDTO> readShopsByCategory(Long categorySeq) {
-        List<Shop> shops = shopRepository.readShopsByCategory(categorySeq);
+    public List<ShopListReadResDTO> readShopsByCategory(Long categorySeq, Integer page) {
+        if (page == null || page < 1) {
+            throw new CustomException(ErrorCodeType.INVALID_VALUE);
+        }
+
+        int pageSize = 6;
+        Pageable pageable = PageRequest.of(page - 1, pageSize);
+
+        List<Shop> shops = shopRepository.readShopsByCategory(categorySeq, pageable);
         return shops.stream()
                 .map(shop -> {
                     ShopListReadResDTO shopListReadResDTO = modelMapper.map(shop, ShopListReadResDTO.class);


### PR DESCRIPTION
## 📖개요
카테고리 별 매장 조회 기능 구현

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #56

## 💻작업사항
- 카테고리 별 매장 조회 기능 구현 (승인 완료, 삭제되지 않은 매장만 조회)
<br>

![image](https://github.com/user-attachments/assets/92075ee7-dafa-421f-8af2-b4cabfcacd92)

## 💡작성한 이슈 외에 작업한 사항
- book 엔티티 table name 수정
- 매장 마감 시간 컬럼명(shop_deadline -> shop_closed_at) 및 타입 변경(LocalDateTime -> LocalTime)
